### PR TITLE
Updates .gitattributes, added export-ignore.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,8 +18,6 @@ readme.rst
 tests/codeigniter/ export-ignore
 tests/travis/ export-ignore
 
-# User Guide Source Files
-user_guide_src
-
-# User Guide Compiled Files
+# User Guide source files and compiled files
+user_guide_src export-ignore
 user_guide export-ignore


### PR DESCRIPTION
Excludes `user_guide_src` via `--prefer-dist` composer installation. 

Refer to this https://github.com/bcit-ci/CodeIgniter/issues/5843#issuecomment-889615837 based on this https://github.com/bcit-ci/CodeIgniter/pull/3831

> This basically just removes a number of development-only files (like the user guide source and our tests) from any installs made through composer with the --prefer-dist flag set.
> 
> Helps create a faster install with less unnecessary files to new projects.